### PR TITLE
Added functionality to specify an API bind address

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,12 +58,14 @@ func main() {
 	go keepalive.InitKeepAlive("confd", paramsDirName)
 
 	foundConfPort, confPort := server.GetConfigHandlerPort(paramsDirName)
+        confAddress := server.GetConfigHandlerAddress(paramsDirName)
+
 	if foundConfPort {
-		logger.Info("Starting config listener on port:", confPort)
-		err = http.ListenAndServe(":"+confPort, restRtr)
+		logger.Info("Starting config listener on " + confAddress + ":" + confPort)
+		err = http.ListenAndServe(confAddress + ":" + confPort, restRtr)
 	} else {
-		logger.Info("Starting config listener on port: 8080")
-		err = http.ListenAndServe(":8080", restRtr)
+		logger.Info("Starting config listener on " + confAddress + ":8080")
+		err = http.ListenAndServe(confAddress + ":8080", restRtr)
 	}
 	if err != nil {
 		logger.Err("Failed to start config listener:", err)

--- a/server/configmgr.go
+++ b/server/configmgr.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	modelObjs "models/objects"
+        "net"
 	"os"
 	"os/signal"
 	"strconv"
@@ -61,6 +62,7 @@ const (
 
 type SysProfile struct {
 	API_Port int `json:"API_Port"`
+        API_Address string `json:"API_Address"`
 }
 
 // Get the http port on which rest api calls will be received
@@ -82,6 +84,43 @@ func GetConfigHandlerPort(paramsDir string) (bool, string) {
 	}
 	port = strconv.Itoa(sysProfile.API_Port)
 	return true, port
+}
+
+// Get the ip address on which rest api server will bind
+func GetConfigHandlerAddress(paramsDir string) (string) {
+	var sysProfile SysProfile
+
+        // Default bind API to *:<port>
+        ipAddress := "0.0.0.0"
+
+	sysProfileFile := paramsDir + "systemProfile.json"
+	bytes, err := ioutil.ReadFile(sysProfileFile)
+
+	if err != nil {
+		gConfigMgr.logger.Err("Error in reading globals file", sysProfileFile)
+		return ipAddress
+	}
+
+	err = json.Unmarshal(bytes, &sysProfile)
+	if err != nil {
+		gConfigMgr.logger.Err("Failed to Unmarshall Json")
+		return ipAddress
+	}
+
+	tmpIpAddress, err := net.ResolveIPAddr("", sysProfile.API_Address)
+        if err != nil {
+            // If we could not resolve the provided IP.  net.ResolveIPAddr() 
+            // will allow us to set a name or IP for the API_Address config
+            // entry
+	    return ipAddress
+        } else if tmpIpAddress.String() == ""{
+            // if sysProfile.API_Address is undefined, then tmpIpAddress will 
+            // be ""
+            return ipAddress
+        } else {
+            // Valid address in config
+            return tmpIpAddress.String()
+        }
 }
 
 //


### PR DESCRIPTION
## DEPENDANT PULLS
NO

## Description
The ability to provide an `API_Address` string parameter within `/opt/flexswitch/params/systemProfile.json`.  This can either be a resolvable hostname or IP address.  If the lookup fails, it will default bind to `0.0.0.0:<API_Port>`.  This does not prevent the user from using an IP which flexswitch cannot bind to, but that should get caught when `http.ListenAndServe()` fails.

I'm not sure if there was a larger reason for not including the ability to bind to a specific port, but if we have to implement flexswitch security by using NGINX, I'd prefer to force the API to bind to localhost than to have to use iptables.  I'm sure others may agree with this sentiment as well, but if there's some overarching architectural reason for not wanting this, then I would love to discuss.

I'm not sure where to put any unit testing for this in.  If you could let me know, I'll work to add a test.

## Bug fixes for
None

## Reviewer

## Check list
- [ ] Code Review
- [ ] Unit Test

## Unit test output


